### PR TITLE
add `image_id` to `Shopify.Resources.Variant`

### DIFF
--- a/lib/shopify/resources/variant.ex
+++ b/lib/shopify/resources/variant.ex
@@ -27,6 +27,7 @@ defmodule Shopify.Variant do
     :grams,
     :weight,
     :weight_unit,
+    :image_id,
     :id,
     :inventory_item_id,
     :inventory_management,


### PR DESCRIPTION
Since we're forking Shopify for The Loyalist to have an "in-house" fork,
we want to include the `image_id`-variant work that was already included in the 
fork The Loyalist currently relies on (https://github.com/larskluge/shopify/). 
